### PR TITLE
Update Dockerfile to fix #7529

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,6 @@ RUN ./docker/build/finalize.sh
 # Configure Docker Container
 VOLUME ["/data", "/backup"]
 EXPOSE 22 3000
-HEALTHCHECK CMD (curl -o /dev/null -sS http://localhost:3000/healthcheck) || exit 1
+HEALTHCHECK CMD (curl --noproxy localhost -o /dev/null -sS http://localhost:3000/healthcheck) || exit 1
 ENTRYPOINT ["/app/gogs/docker/start.sh"]
 CMD ["/bin/s6-svscan", "/app/gogs/docker/s6/"]


### PR DESCRIPTION
Add `--noproxy` for localhost to prevent from using a proxy for this request

## Describe the pull request

This PR fixes #7529.

When the environment variables `HTTP_PROXY` and/or `HTTPS_PROXY` are set, the routing even for localhost goes through the proxy. In cases where the docker image uses a port redirection this request fails.
When accessing itself as a host a proxy is not really needed so this is disabled in the ```HEALTHCHECK```.

Link to the issue: [#7529](https://github.com/gogs/gogs/issues/7529)

## Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/gogs/gogs/blob/main/.github/CONTRIBUTING.md).
- [x] I have added test cases to cover the new code or have provided the test plan.

## Test plan

This fix can be verified by starting a docker container with the following additional parameters: `-e HTTP_PROXY=host.docker.internal -e HTTPS_PROXY=host.docker.internal`. When this fix is not present a `docker inspect` or a `docker ps` will show the container as unhealthy. With this fix the container is healthy.

A command for verification could look like this:
```
docker run -d -e HTTP_PROXY=host.docker.internal -e HTTPS_PROXY=host.docker.internal --name gogs_test gogs/gogs:latest

docker ps gogs_test
```
